### PR TITLE
Refactor OC Responses

### DIFF
--- a/Sources/AgoraRtm/Documentation.docc/Channel-Topics.md
+++ b/Sources/AgoraRtm/Documentation.docc/Channel-Topics.md
@@ -27,7 +27,7 @@ After successfully joining a Topic, the SDK triggers an ``RtmClientDelegate/rtmC
 ```swift
 do {
     _ = try await streamChannel.joinTopic("Basketball", with: nil)
-} catch let err as RtmBaseErrorInfo {
+} catch let err as RtmErrorInfo {
     print("\(err.operation) failed, errorCode \(err.errorCode), reason \(err.reason)")
 }
 ```
@@ -43,7 +43,7 @@ If you no longer want to send messages within a topic or exceed the limit for si
 ```swift
 do {
     _ = try await streamChannel.leave()
-} catch let err as RtmBaseErrorInfo {
+} catch let err as RtmErrorInfo {
     print("leave topic failed, errorCode \(err.errorCode), reason \(err.reason)")
 }
 ```
@@ -64,7 +64,7 @@ do {
         toTopic: "Basketball",
         withOptions: RtmTopicOption(users: ["user-1", "user-2"])
     )
-} catch let err as RtmBaseErrorInfo {
+} catch let err as RtmErrorInfo {
     print("subscription failed, errorCode \(err.errorCode), reason \(err.reason)")
 }
 ```
@@ -87,7 +87,7 @@ do {
         fromTopic: "Basketball",
         withOptions: RtmTopicOption(users: ["user-1", "user-2"])
     )
-} catch let err as RtmBaseErrorInfo {
+} catch let err as RtmErrorInfo {
     print("unsubscribe failed, errorCode \(err.errorCode), reason \(err.reason)")
 }
 ```

--- a/Sources/AgoraRtm/Documentation.docc/Documentation.md
+++ b/Sources/AgoraRtm/Documentation.docc/Documentation.md
@@ -24,8 +24,8 @@ AgoraRtm is a class that provides real-time messaging functionalities for applic
 
 ### Errors
 
-- ``RtmBaseErrorInfo``
-- ``RtmBaseErrorCode``
+- ``RtmErrorInfo``
+- ``RtmErrorCode``
 
 ### Messages
 

--- a/Sources/AgoraRtm/Documentation.docc/Messages.md
+++ b/Sources/AgoraRtm/Documentation.docc/Messages.md
@@ -51,7 +51,7 @@ try? await rtmClient.publish(
 
 Synchronous option for publishing is also available.
 
-The async method will throw an error of type ``RtmBaseErrorInfo`` if there's any issue creating the message or publishing it.
+The async method will throw an error of type ``RtmErrorInfo`` if there's any issue creating the message or publishing it.
 
 ## Receiving Messages
 
@@ -71,7 +71,7 @@ try? await rtmClient.subscribe(
 )
 ```
 
-The async method will throw an error of type ``RtmBaseErrorInfo`` if there's any issue subscribing to the channel.
+The async method will throw an error of type ``RtmErrorInfo`` if there's any issue subscribing to the channel.
 
 ### Delegate Message Events
 

--- a/Sources/AgoraRtm/Documentation.docc/Stream-Channels.md
+++ b/Sources/AgoraRtm/Documentation.docc/Stream-Channels.md
@@ -24,7 +24,7 @@ After creating an ``RtmStreamChannel`` instance, use the ``RtmStreamChannel/join
 do {
     let joinOptions = RtmJoinChannelOption(token: "agora-token", features = .presence)
     _ = try await streamChannel.join(with: options)
-} catch let err as RtmBaseErrorInfo {
+} catch let err as RtmErrorInfo {
     print("join failed, errorCode \(err.errorCode), reason \(err.reason)")
 }
 ```

--- a/Sources/AgoraRtm/RtmClientKit.swift
+++ b/Sources/AgoraRtm/RtmClientKit.swift
@@ -56,58 +56,41 @@ open class RtmClientKit: NSObject {
     ///   - completion: The completion handler to call when the login operation is complete.
     public func login(
         byToken token: String?,
-        completion: ((Result<AgoraRtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
-        agoraRtmClient.login(byToken: token) { loginResp, loginErr in
-            guard let completion = completion else { return }
-            guard let response = loginResp else {
-                completion(.failure(RtmBaseErrorInfo(from: loginErr) ?? .noKnownError(operation: #function)))
-                return
-            }
-            completion(.success(response))
+        agoraRtmClient.login(byToken: token) { loginResp, err in
+            // TODO: Login should not return a response if there's an error
+            RtmClientKit.handleCompletion((loginResp, err), completion: completion, operation: #function)
         }
     }
 
     /// Asynchronously logs into the Agora RTM system.
     ///
     /// - Parameter token: The token to log in with.
-    /// - Returns: A ``RtmCommonResponse`` if the login is successful, otherwise throws an ``RtmBaseErrorInfo`` error.
+    /// - Returns: A ``RtmCommonResponse`` if the login is successful, otherwise throws an ``RtmErrorInfo`` error.
     @available(iOS 13.0.0, *) @discardableResult
     public func login(byToken token: String? = nil) async throws -> RtmCommonResponse {
-        let (loginResp, err) = await agoraRtmClient.login(byToken: token)
-        if let response = loginResp {
-            return .init(response)
-        }
-        throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
+        return try RtmClientKit.handleCompletion(await agoraRtmClient.login(byToken: token), operation: #function)
     }
 
     /// Logs out of the Agora RTM system.
     ///
     /// - Parameter completion: The completion handler to call when the logout operation is complete.
     public func logout(
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         agoraRtmClient.logout() { resp, logoutErr in
-            guard let completion = completion else { return }
-            guard let resp else {
-                completion(.failure(RtmBaseErrorInfo(from: logoutErr) ?? .noKnownError(operation: #function)))
-                return
-            }
-            completion(.success(.init(resp)))
+            RtmClientKit.handleCompletion((resp, logoutErr), completion: completion, operation: #function)
         }
     }
 
     /// Asynchronously logs out of the Agora RTM system.
     ///
-    /// This method can throw an ``RtmBaseErrorInfo`` error if the logout operation fails.
+    /// This method can throw an ``RtmErrorInfo`` error if the logout operation fails.
     @available(iOS 13.0.0, *)
     @discardableResult
     public func logout() async throws -> RtmCommonResponse {
-        let (resp, err) = await agoraRtmClient.logout()
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(await agoraRtmClient.logout(), operation: #function)
     }
 
     /// Renews the token for the Agora RTM client.
@@ -117,15 +100,10 @@ open class RtmClientKit: NSObject {
     ///   - completion: The completion handler to call when the token renewal operation is complete.
     public func renewToken(
         _ token: String,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
-        agoraRtmClient.renewToken(token) { resp, renewErr in
-            guard let completion = completion else { return }
-            guard let resp = resp else {
-                completion(.failure(RtmBaseErrorInfo(from: renewErr) ?? .noKnownError(operation: #function)))
-                return
-            }
-            completion(.success(.init(resp)))
+        agoraRtmClient.renewToken(token) { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         }
     }
 
@@ -134,14 +112,10 @@ open class RtmClientKit: NSObject {
     /// - Parameters:
     ///   - token: The new token to renew.
     ///
-    /// This method can throw a ``RtmBaseErrorInfo`` error if the token renewal operation fails.
+    /// This method can throw a ``RtmErrorInfo`` error if the token renewal operation fails.
     @available(iOS 13.0.0, *) @discardableResult
     public func renewToken(_ token: String) async throws -> RtmCommonResponse {
-        let (resp, err) = await agoraRtmClient.renewToken(token)
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(await agoraRtmClient.renewToken(token), operation: #function)
     }
 
     /// Subscribes to a channel with the provided name and options.
@@ -155,15 +129,10 @@ open class RtmClientKit: NSObject {
     public func subscribe(
         toChannel channelName: String,
         features: RtmSubscribeFeatures = [.messages, .presence],
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
-        agoraRtmClient.subscribe(withChannel: channelName, option: features.objcVersion) { resp, subErr in
-            guard let completion = completion else { return }
-            guard let resp = resp else {
-                completion(.failure(RtmBaseErrorInfo(from: subErr) ?? .noKnownError(operation: #function)))
-                return
-            }
-            completion(.success(.init(resp)))
+        agoraRtmClient.subscribe(withChannel: channelName, option: features.objcVersion) { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         }
     }
 
@@ -178,11 +147,9 @@ open class RtmClientKit: NSObject {
     public func subscribe(
         toChannel channelName: String, features: RtmSubscribeFeatures = [.messages, .presence]
     ) async throws -> RtmCommonResponse {
-        let (resp, err) = await agoraRtmClient.subscribe(withChannel: channelName, option: features.objcVersion)
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(await agoraRtmClient.subscribe(
+            withChannel: channelName, option: features.objcVersion
+        ), operation: #function)
     }
 
     /// Unsubscribes from a channel with the provided name.
@@ -194,15 +161,10 @@ open class RtmClientKit: NSObject {
     ///   which indicates the response of the unsubscription operation.
     public func unsubscribe(
         fromChannel channelName: String,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
-        agoraRtmClient.unsubscribe(withChannel: channelName) { resp, subErr in
-            guard let completion = completion else { return }
-            guard let resp = resp else {
-                completion(.failure(RtmBaseErrorInfo(from: subErr) ?? .noKnownError(operation: #function)))
-                return
-            }
-            completion(.success(.init(resp)))
+        agoraRtmClient.unsubscribe(withChannel: channelName) { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         }
     }
 
@@ -214,12 +176,9 @@ open class RtmClientKit: NSObject {
     /// This method can throw a ``RtmCommonResponse`` error if the unsubscription operation fails.
     @available(iOS 13.0.0, *) @discardableResult
     public func unsubscribe(fromChannel channelName: String) async throws -> RtmCommonResponse {
-        let (resp, err) = await agoraRtmClient.unsubscribe(withChannel: channelName)
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-//            throw RtmUnsubscribeErrorInfo(from: err) ?? .noKnownError
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(
+            await agoraRtmClient.unsubscribe(withChannel: channelName), operation: #function
+        )
     }
 
     /// Publishes a message in the specified channel.
@@ -235,30 +194,24 @@ open class RtmClientKit: NSObject {
         message: Codable,
         to channelName: String,
         withOption publishOption: RtmPublishOptions? = nil,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         let msgString: String
         do {
             msgString = try message.convertToString()
-        } catch let error as RtmBaseErrorInfo {
+        } catch let error as RtmErrorInfo {
             completion?(.failure(error))
             return
         } catch {
-            completion?(.failure(RtmBaseErrorInfo(
+            completion?(.failure(RtmErrorInfo(
                 errorCode: .channelInvalidMessage, operation: #function,
                 reason: "could not encode message: \(error.localizedDescription)"
             )))
             return
         }
 
-        agoraRtmClient.publish(channelName, message: msgString as NSString, withOption: publishOption?.objcVersion) { resp, pubErr in
-            guard let completion = completion else { return }
-            guard let resp = resp else {
-                completion(.failure(RtmBaseErrorInfo(from: pubErr) ?? .noKnownError(operation: #function)))
-//                completion(.failure(RtmPublishErrorInfo(from: pubErr) ?? .noKnownError))
-                return
-            }
-            completion(.success(.init(resp)))
+        agoraRtmClient.publish(channelName, message: msgString as NSString, withOption: publishOption?.objcVersion) { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         }
     }
 
@@ -269,7 +222,7 @@ open class RtmClientKit: NSObject {
     ///   - channelName: The name of the channel to publish the message to.
     ///   - publishOption: The options for publishing the message.
     ///
-    /// This method will throw an ``RtmBaseErrorInfo`` if the encoding or publish operation fails.
+    /// This method will throw an ``RtmErrorInfo`` if the encoding or publish operation fails.
     @discardableResult @available(iOS 13.0.0, *)
     public func publish(
         message: Codable, to channelName: String, withOption publishOption: RtmPublishOptions? = nil
@@ -277,30 +230,30 @@ open class RtmClientKit: NSObject {
         let msgString: String
         do {
             msgString = try message.convertToString()
-        } catch let error as RtmBaseErrorInfo {
+        } catch let error as RtmErrorInfo {
             throw error
         } catch {
-            throw RtmBaseErrorInfo(
+            throw RtmErrorInfo(
                 errorCode: .channelInvalidMessage, operation: #function,
                 reason: "could not encode message: \(error.localizedDescription)"
             )
         }
-        let (resp, err) = await agoraRtmClient.publish(channelName, message: msgString as NSString, withOption: publishOption?.objcVersion)
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(await agoraRtmClient.publish(
+            channelName,
+            message: msgString as NSString,
+            withOption: publishOption?.objcVersion
+        ), operation: #function)
     }
 
     /// Sets the parameters for the Agora RTM client.
     ///
     /// - Parameter parameters: The parameters to set.
     ///
-    /// This method can throw an ``RtmBaseErrorInfo`` error if the parameter setting fails.
+    /// This method can throw an ``RtmErrorInfo`` error if the parameter setting fails.
     public func setParameters(_ parameters: String) throws {
         let err = agoraRtmClient.setParameters(parameters)
         if err != .ok {
-            throw RtmBaseErrorInfo(errorCode: err.rawValue, operation: #function, reason: "")
+            throw RtmErrorInfo(errorCode: err.rawValue, operation: #function, reason: "")
         }
     }
 
@@ -316,8 +269,8 @@ open class RtmClientKit: NSObject {
     /// Destroys the Agora RTM client.
     ///
     /// - Returns: The error code indicating the result of the destruction, or nil if successful.
-    public func destroy() -> RtmBaseErrorCode? {
-        RtmBaseErrorCode(rawValue: agoraRtmClient.destroy().rawValue)
+    public func destroy() -> RtmErrorCode? {
+        RtmErrorCode(rawValue: agoraRtmClient.destroy().rawValue)
     }
 }
 
@@ -384,7 +337,7 @@ public extension RtmClientKit {
     ///
     /// - Parameter errorCode: The error code for which to get the reason.
     /// - Returns: The error reason string or nil if the error code is invalid.
-    static func getErrorReason(_ errorCode: RtmBaseErrorCode) -> String? {
+    static func getErrorReason(_ errorCode: RtmErrorCode) -> String? {
         guard let agoraErr = AgoraRtmErrorCode(
             rawValue: errorCode.rawValue
         ) else { return nil }
@@ -397,4 +350,25 @@ public extension RtmClientKit {
     static func getVersion() -> String {
         AgoraRtmClientKit.getVersion()
     }
+}
+
+// Functions to handle the response cases for the objc library
+internal extension RtmClientKit {
+    static func handleCompletion<T: RtmResponseProtocol>(_ block: (resp: T.ResponseType?, err: AgoraRtmErrorInfo), completion: ((Result<T, RtmErrorInfo>) -> Void)? = nil, operation: String) {
+        // TODO: No function should not return a response if there's an error
+        guard let completion else { return }
+        if let err = RtmErrorInfo(from: block.err) { return completion(.failure(err)) }
+        guard let resp = block.resp else {
+            return completion(.failure(.noKnownError(operation: operation)))
+        }
+        completion(.success(T.init(resp)))
+    }
+
+    static func handleCompletion<T: RtmResponseProtocol>(_ block: (resp: T.ResponseType?, err: AgoraRtmErrorInfo), operation: String) throws -> T {
+        // TODO: No function should not return a response if there's an error
+        if let err = RtmErrorInfo(from: block.err) { throw err }
+        guard let resp = block.resp else { throw RtmErrorInfo.noKnownError(operation: #function) }
+        return .init(resp)
+    }
+
 }

--- a/Sources/AgoraRtm/RtmClientResponses.swift
+++ b/Sources/AgoraRtm/RtmClientResponses.swift
@@ -7,17 +7,24 @@
 
 import AgoraRtmKit
 
-public class RtmCommonResponse {
-    // You can add properties if needed, but this class doesn't have any specific properties in the Objective-C counterpart.
-    private let response: AgoraRtmCommonResponse
+internal protocol RtmResponseProtocol {
+    associatedtype ResponseType
 
-    init(_ response: AgoraRtmCommonResponse) {
+    var response: ResponseType { get }
+    init(_ response: ResponseType)
+}
+
+public class RtmCommonResponse: RtmResponseProtocol {
+    // You can add properties if needed, but this class doesn't have any specific properties in the Objective-C counterpart.
+    internal let response: AgoraRtmCommonResponse
+
+    required internal init(_ response: AgoraRtmCommonResponse) {
         self.response = response
     }
 }
 
-public class RtmTopicSubscriptionResponse {
-    private let response: AgoraRtmTopicSubscriptionResponse
+public class RtmTopicSubscriptionResponse: RtmResponseProtocol {
+    internal let response: AgoraRtmTopicSubscriptionResponse
 
     public var succeedUsers: [String] {
         return response.succeedUsers
@@ -27,7 +34,7 @@ public class RtmTopicSubscriptionResponse {
         return response.failedUsers
     }
 
-    init(_ response: AgoraRtmTopicSubscriptionResponse) {
+    required internal init(_ response: AgoraRtmTopicSubscriptionResponse) {
         self.response = response
     }
 }
@@ -121,32 +128,32 @@ public class RtmMetadata {
     }
 }
 
-public class RtmGetMetadataResponse {
-    private let response: AgoraRtmGetMetadataResponse
+public class RtmGetMetadataResponse: RtmResponseProtocol {
+    internal let response: AgoraRtmGetMetadataResponse
 
     public var data: RtmMetadata? {
         return .init(response.data)
     }
 
-    init(_ response: AgoraRtmGetMetadataResponse) {
+    required init(_ response: AgoraRtmGetMetadataResponse) {
         self.response = response
     }
 }
 
-public class RtmGetLocksResponse {
-    private let response: AgoraRtmGetLocksResponse
+public class RtmGetLocksResponse: RtmResponseProtocol {
+    internal let response: AgoraRtmGetLocksResponse
 
     public lazy var lockDetailList: [RtmLockDetail] = {
         return response.lockDetailList.map { .init($0) }
     }()
 
-    init(_ response: AgoraRtmGetLocksResponse) {
+    required internal init(_ response: AgoraRtmGetLocksResponse) {
         self.response = response
     }
 }
 
-public class RtmOnlineUsersResponse {
-    private let response: AgoraRtmWhoNowResponse
+public class RtmOnlineUsersResponse: RtmResponseProtocol {
+    internal let response: AgoraRtmWhoNowResponse
 
     public var totalOccupancy: Int32 {
         return response.totalOccupancy
@@ -166,7 +173,7 @@ public class RtmOnlineUsersResponse {
         return response.nextPage
     }
 
-    init(_ response: AgoraRtmWhoNowResponse) {
+    required internal init(_ response: AgoraRtmWhoNowResponse) {
         self.response = response
     }
 }
@@ -175,8 +182,8 @@ public class RtmOnlineUsersResponse {
 public typealias RtmWhoNowResponse = RtmOnlineUsersResponse
 
 
-public class RtmUserChannelsResponse {
-    private let response: AgoraRtmWhereNowResponse
+public class RtmUserChannelsResponse: RtmResponseProtocol {
+    internal let response: AgoraRtmWhereNowResponse
 
     public var totalChannel: Int32 {
         return response.totalChannel
@@ -186,7 +193,7 @@ public class RtmUserChannelsResponse {
         return response.channels.map { .init($0) }
     }()
 
-    internal init(_ response: AgoraRtmWhereNowResponse) {
+    required internal init(_ response: AgoraRtmWhereNowResponse) {
         self.response = response
     }
 }
@@ -194,8 +201,8 @@ public class RtmUserChannelsResponse {
 @available(*, deprecated, renamed: "RtmUserChannelsResponse")
 public typealias RtmWhereNowResponse = RtmUserChannelsResponse
 
-public class RtmPresenceGetStateResponse {
-    private let response: AgoraRtmPresenceGetStateResponse
+public class RtmPresenceGetStateResponse: RtmResponseProtocol {
+    internal let response: AgoraRtmPresenceGetStateResponse
 
     public var states: [String: String] {
         return response.state.states.reduce(into: [String: String]()) { result, keyValue in
@@ -203,7 +210,7 @@ public class RtmPresenceGetStateResponse {
         }
     }
 
-    init(_ response: AgoraRtmPresenceGetStateResponse) {
+    required internal init(_ response: AgoraRtmPresenceGetStateResponse) {
         self.response = response
     }
 }

--- a/Sources/AgoraRtm/RtmErrorCode.swift
+++ b/Sources/AgoraRtm/RtmErrorCode.swift
@@ -1,5 +1,5 @@
 //
-//  SignalingErrorCode.swift
+//  RtmErrorCode.swift
 //  
 //
 //  Created by Max Cobb on 07/08/2023.
@@ -28,9 +28,9 @@ extension RtmError {
 }
 
 /// A base error information struct that implements the `RtmError` protocol, providing error details for the Agora RTM SDK.
-public struct RtmBaseErrorInfo: RtmError {
+public struct RtmErrorInfo: RtmError {
     /// The error code associated with the error.
-    public let errorCode: RtmBaseErrorCode
+    public let errorCode: RtmErrorCode
 
     /// The raw error code value received from the SDK.
     public let rawErrorCode: Int
@@ -41,14 +41,14 @@ public struct RtmBaseErrorInfo: RtmError {
     /// The reason or description of the error.
     public let reason: String
 
-    /// Create an `RtmBaseErrorInfo` instance with the specified error code, operation name, and reason.
+    /// Create an `RtmErrorInfo` instance with the specified error code, operation name, and reason.
     ///
     /// - Parameters:
     ///   - errorCode: The error code to associate with the error.
     ///   - operation: The name of the operation where the error occurred.
     ///   - reason: The reason or description of the error.
     internal init(errorCode: Int, operation: String, reason: String) {
-        self.errorCode = RtmBaseErrorCode(rawValue: errorCode) ?? .unknown
+        self.errorCode = RtmErrorCode(rawValue: errorCode) ?? .unknown
         self.operation = operation
         self.reason = reason
         self.rawErrorCode = errorCode
@@ -58,22 +58,22 @@ public struct RtmBaseErrorInfo: RtmError {
         }
     }
 
-    /// Create an `RtmBaseErrorInfo` instance with the specified error code, operation name, and reason.
+    /// Create an `RtmErrorInfo` instance with the specified error code, operation name, and reason.
     ///
     /// - Parameters:
-    ///   - errorCode: The `RtmBaseErrorCode` to associate with the error.
+    ///   - errorCode: The ``RtmErrorCode`` to associate with the error.
     ///   - operation: The name of the operation where the error occurred.
     ///   - reason: The reason or description of the error.
-    internal init(errorCode: RtmBaseErrorCode, operation: String, reason: String) {
+    internal init(errorCode: RtmErrorCode, operation: String, reason: String) {
         self.init(errorCode: errorCode.rawValue, operation: operation, reason: reason)
     }
 
-    /// Create an `RtmBaseErrorInfo` instance for cases where there is no known error, but the RTM SDK returned no valid response.
+    /// Create an `RtmErrorInfo` instance for cases where there is no known error, but the RTM SDK returned no valid response.
     ///
     /// - Parameter operation: The name of the function where the event occurred.
-    /// - Returns: A new `RtmBaseErrorInfo` object with the error code set to `-1`.
-    internal static func noKnownError(operation: String) -> RtmBaseErrorInfo {
-        RtmBaseErrorInfo(
+    /// - Returns: A new `RtmErrorInfo` object with the error code set to `-1`.
+    internal static func noKnownError(operation: String) -> RtmErrorInfo {
+        RtmErrorInfo(
             errorCode: -1,
             operation: operation,
             reason: "\(operation) did not fail or return a response"
@@ -81,7 +81,8 @@ public struct RtmBaseErrorInfo: RtmError {
     }
 }
 
-public enum RtmBaseErrorCode: Int, ErrorCode {
+public enum RtmErrorCode: Int, ErrorCode {
+    // `ok` is not a valid error, absence of an error indicates no error.
 //    case ok = 0
     case unknown = -1
     case notInitialized = -10001
@@ -177,7 +178,7 @@ public enum RtmBaseErrorCode: Int, ErrorCode {
     case lockNotAvailable = -14009
 }
 
-internal extension RtmClientKit {
+private extension RtmClientKit {
     struct RtmLoginErrorInfo: RtmError {
         let errorCode: LoginErrorCode
         let rawErrorCode: Int

--- a/Sources/AgoraRtm/RtmLock+Async.swift
+++ b/Sources/AgoraRtm/RtmLock+Async.swift
@@ -21,15 +21,11 @@ extension RtmLock {
         ttl: Int32
     ) async throws -> RtmCommonResponse {
         let (channelName, channelType) = channel.objcVersion
-        let (resp, err) = await self.lock.setLock(
+        return try RtmClientKit.handleCompletion(await self.lock.setLock(
             channelName, channelType: channelType,
             lockName: lockName,
             ttl: ttl
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Asynchronously removes a lock from a specified channel.
@@ -42,14 +38,10 @@ extension RtmLock {
         fromChannel channel: RtmChannelDetails
     ) async throws -> RtmCommonResponse {
         let (channelName, channelType) = channel.objcVersion
-        let (resp, err) = await self.lock.remove(
+        return try RtmClientKit.handleCompletion(await self.lock.remove(
             channelName, channelType: channelType,
             lockName: lockName
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Asynchronously acquires a lock on a specified channel.
@@ -64,15 +56,11 @@ extension RtmLock {
         retry: Bool = false
     ) async throws -> RtmCommonResponse {
         let (channelName, channelType) = channel.objcVersion
-        let (resp, err) = await self.lock.acquireLock(
+        return try RtmClientKit.handleCompletion(await self.lock.acquireLock(
             channelName, channelType: channelType,
             lockName: lockName,
             retry: retry
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Asynchronously releases a lock on a specified channel.
@@ -85,14 +73,10 @@ extension RtmLock {
         fromChannel channel: RtmChannelDetails
     ) async throws -> RtmCommonResponse {
         let (channelName, channelType) = channel.objcVersion
-        let (resp, err) = await self.lock.release(
+        return try RtmClientKit.handleCompletion(await self.lock.release(
             channelName, channelType: channelType,
             lockName: lockName
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Asynchronously disables a lock on a specified channel.
@@ -107,15 +91,11 @@ extension RtmLock {
         userId: String
     ) async throws -> RtmCommonResponse {
         let (channelName, channelType) = channel.objcVersion
-        let (resp, err) = await self.lock.revokeLock(
+        return try RtmClientKit.handleCompletion(await self.lock.revokeLock(
             channelName, channelType: channelType,
             lockName: lockName,
             userId: userId
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Asynchronously gets the locks in a specified channel.
@@ -126,11 +106,10 @@ extension RtmLock {
         forChannel channel: RtmChannelDetails
     ) async throws -> RtmGetLocksResponse {
         let (channelName, channelType) = channel.objcVersion
-        let (locks, err) = await self.lock.locks(channelName, channelType: channelType)
-        guard let locks else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(locks)
+        return try RtmClientKit.handleCompletion(
+            await self.lock.locks(channelName, channelType: channelType),
+            operation: #function
+        )
     }
 }
 

--- a/Sources/AgoraRtm/RtmLock.swift
+++ b/Sources/AgoraRtm/RtmLock.swift
@@ -57,7 +57,7 @@ public class RtmLock {
         named lockName: String,
         forChannel channel: RtmChannelDetails,
         ttl: Int32,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         let (channelName, channelType) = channel.objcVersion
         lock.setLock(
@@ -65,12 +65,7 @@ public class RtmLock {
             lockName: lockName,
             ttl: ttl
         ) { resp, error in
-            guard let completion = completion else { return }
-            guard let resp else {
-                completion(.failure(RtmBaseErrorInfo(from: error) ?? .noKnownError(operation: #function)))
-                return
-            }
-            completion(.success(.init(resp)))
+            RtmClientKit.handleCompletion((resp, error), completion: completion, operation: #function)
         }
     }
 
@@ -82,19 +77,14 @@ public class RtmLock {
     public func removeLock(
         named lockName: String,
         fromChannel channel: RtmChannelDetails,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         let (channelName, channelType) = channel.objcVersion
         lock.remove(
             channelName, channelType: channelType,
             lockName: lockName
         ) { resp, error in
-            guard let completion = completion else { return }
-            guard let resp else {
-                completion(.failure(RtmBaseErrorInfo(from: error) ?? .noKnownError(operation: #function)))
-                return
-            }
-            completion(.success(.init(resp)))
+            RtmClientKit.handleCompletion((resp, error), completion: completion, operation: #function)
         }
     }
 
@@ -108,7 +98,7 @@ public class RtmLock {
         named lockName: String,
         fromChannel channel: RtmChannelDetails,
         retry: Bool = false,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         let (channelName, channelType) = channel.objcVersion
         lock.acquireLock(
@@ -116,12 +106,7 @@ public class RtmLock {
             lockName: lockName,
             retry: retry
         ) { resp, error in
-            guard let completion = completion else { return }
-            guard let resp else {
-                completion(.failure(RtmBaseErrorInfo(from: error) ?? .noKnownError(operation: #function)))
-                return
-            }
-            completion(.success(.init(resp)))
+            RtmClientKit.handleCompletion((resp, error), completion: completion, operation: #function)
         }
     }
 
@@ -133,19 +118,14 @@ public class RtmLock {
     public func releaseLock(
         named lockName: String,
         fromChannel channel: RtmChannelDetails,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         let (channelName, channelType) = channel.objcVersion
         lock.release(
             channelName, channelType: channelType,
             lockName: lockName
         ) { resp, error in
-            guard let completion = completion else { return }
-            guard let resp else {
-                completion(.failure(RtmBaseErrorInfo(from: error) ?? .noKnownError(operation: #function)))
-                return
-            }
-            completion(.success(.init(resp)))
+            RtmClientKit.handleCompletion((resp, error), completion: completion, operation: #function)
         }
     }
 
@@ -159,7 +139,7 @@ public class RtmLock {
         named lockName: String,
         fromChannel channel: RtmChannelDetails,
         userId: String,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         let (channelName, channelType) = channel.objcVersion
         lock.revokeLock(
@@ -167,12 +147,7 @@ public class RtmLock {
             lockName: lockName,
             userId: userId
         ) { resp, error in
-            guard let completion = completion else { return }
-            guard let resp else {
-                completion(.failure(RtmBaseErrorInfo(from: error) ?? .noKnownError(operation: #function)))
-                return
-            }
-            completion(.success(.init(resp)))
+            RtmClientKit.handleCompletion((resp, error), completion: completion, operation: #function)
         }
     }
 
@@ -182,15 +157,11 @@ public class RtmLock {
     ///   - completion: A completion block that will be called with the result.
     public func getLocks(
         forChannel channel: RtmChannelDetails,
-        completion: @escaping (Result<RtmGetLocksResponse, Error>) -> Void
+        completion: @escaping (Result<RtmGetLocksResponse, RtmErrorInfo>) -> Void
     ) {
         let (channelName, channelType) = channel.objcVersion
-        lock.getLocks(channelName, channelType: channelType) { locks, error in
-            guard let locks else {
-                completion(.failure(RtmBaseErrorInfo(from: error) ?? .noKnownError(operation: #function)))
-                return
-            }
-            completion(.success(.init(locks)))
+        lock.getLocks(channelName, channelType: channelType) { locks, err in
+            RtmClientKit.handleCompletion((locks, err), completion: completion, operation: #function)
         }
     }
 }

--- a/Sources/AgoraRtm/RtmPresence+Async.swift
+++ b/Sources/AgoraRtm/RtmPresence+Async.swift
@@ -20,14 +20,10 @@ public extension RtmPresence {
         in channel: RtmChannelDetails, options: RtmPresenceOptions? = nil
     ) async throws -> RtmOnlineUsersResponse {
         let (channelName, channelType) = channel.objcVersion
-        let (resp, err) = await self.presence.whoNow(
+        return try RtmClientKit.handleCompletion(await self.presence.whoNow(
             channelName, channelType: channelType,
             options: options?.objcVersion
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Asynchronously queries which channels a user is currently in.
@@ -36,11 +32,7 @@ public extension RtmPresence {
     ///   - userId: The ID of the user.
     /// - Returns: A ``RtmWhereNowResponse`` object with either the query response.
     func fetchUserChannels(for userId: String) async throws -> RtmUserChannelsResponse {
-        let (resp, err) = await self.presence.whereNow(userId)
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(await self.presence.whereNow(userId), operation: #function)
     }
 
     /// Asynchronously queries who is currently in a specified channel.
@@ -80,13 +72,13 @@ public extension RtmPresence {
     /// to join or subscribe, the state data is immediately activated, which can subsequently trigger relevant
     /// event notifications.
     ///
-    /// - Throws: An ``RtmBaseErrorInfo`` error if the state update operation encounters any problems.
+    /// - Throws: An ``RtmErrorInfo`` error if the state update operation encounters any problems.
     func setUserState(
         inChannel channel: RtmChannelDetails,
         to states: [String: String]
     ) async throws -> RtmCommonResponse {
         let (channelName, channelType) = channel.objcVersion
-        let (resp, err) = await self.presence.setState(
+        return try RtmClientKit.handleCompletion(await self.presence.setState(
             channelName, channelType: channelType,
             items: states.map {
                 let stateItem = AgoraRtmStateItem()
@@ -94,11 +86,7 @@ public extension RtmPresence {
                 stateItem.value = $0.value
                 return stateItem
             }
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Asynchronously removes specified state entries of the local user from a given channel.
@@ -113,14 +101,10 @@ public extension RtmPresence {
         keys: [String]
     ) async throws -> RtmCommonResponse {
         let (channelName, channelType) = channel.objcVersion
-        let (resp, err) = await self.presence.removeState(
+        return try RtmClientKit.handleCompletion(await self.presence.removeState(
             channelName, channelType: channelType,
             items: keys
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Asynchronously gets user state for a specified user in a channel.
@@ -132,16 +116,12 @@ public extension RtmPresence {
     func getState(
         ofUser userId: String,
         inChannel channel: RtmChannelDetails
-    ) async throws -> [String: String] {
+    ) async throws -> RtmPresenceGetStateResponse {
         let (channelName, channelType) = channel.objcVersion
-        let (resp, err) = await self.presence.state(
+        return try RtmClientKit.handleCompletion(await self.presence.state(
             channelName, channelType: channelType,
             userId: userId
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return RtmPresenceGetStateResponse(resp).states
+        ), operation: #function)
     }
 }
 

--- a/Sources/AgoraRtm/RtmPresence.swift
+++ b/Sources/AgoraRtm/RtmPresence.swift
@@ -76,22 +76,18 @@ public class RtmPresence {
     /// - Parameters:
     ///   - channel: The type and name of the channel.
     ///   - options: The query option. Default is nil.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmWhoNowResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmWhoNowResponse, RtmErrorInfo>`.
     public func fetchOnlineUsers(
         inChannel channel: RtmChannelDetails,
         options: RtmPresenceOptions? = nil,
-        completion: @escaping (Result<RtmOnlineUsersResponse, RtmBaseErrorInfo>) -> Void
+        completion: @escaping (Result<RtmOnlineUsersResponse, RtmErrorInfo>) -> Void
     ) {
         let (channelName, channelType) = channel.objcVersion
         presence.whoNow(
             channelName, channelType: channelType,
             options: options?.objcVersion
-        ) { response, error in
-            if let response = response {
-                completion(.success(.init(response)))
-                return
-            }
-            completion(.failure(RtmBaseErrorInfo(from: error) ?? .noKnownError(operation: #function)))
+        ) { response, err in
+            RtmClientKit.handleCompletion((response, err), completion: completion, operation: #function)
         }
     }
 
@@ -99,31 +95,27 @@ public class RtmPresence {
     public func whoNow(
         inChannel channel: RtmChannelDetails,
         options: RtmPresenceOptions? = nil,
-        completion: @escaping (Result<RtmOnlineUsersResponse, RtmBaseErrorInfo>) -> Void
+        completion: @escaping (Result<RtmOnlineUsersResponse, RtmErrorInfo>) -> Void
     ) { self.fetchOnlineUsers(inChannel: channel, options: options, completion: completion) }
 
     /// Queries which channels the specified user has joined.
     ///
     /// - Parameters:
     ///   - userId: The ID of the user.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmWhereNowResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmWhereNowResponse, RtmErrorInfo>`.
     public func fetchUserChannels(
         userId: String,
-        completion: @escaping (Result<RtmUserChannelsResponse, RtmBaseErrorInfo>) -> Void
+        completion: @escaping (Result<RtmUserChannelsResponse, RtmErrorInfo>) -> Void
     ) {
-        presence.whereNow(userId) { response, error in
-            if let response = response {
-                completion(.success(.init(response)))
-                return
-            }
-            completion(.failure(RtmBaseErrorInfo(from: error) ?? .noKnownError(operation: #function)))
+        presence.whereNow(userId) { response, err in
+            RtmClientKit.handleCompletion((response, err), completion: completion, operation: #function)
         }
     }
 
     @available(*, deprecated, renamed: "fetchUserChannels(userId:completion:)")
     public func whereNow(
         userId: String,
-        completion: @escaping (Result<RtmUserChannelsResponse, RtmBaseErrorInfo>) -> Void
+        completion: @escaping (Result<RtmUserChannelsResponse, RtmErrorInfo>) -> Void
     ) { self.fetchUserChannels(userId: userId, completion: completion) }
 
     /// Sets the local user's state within a specified channel.
@@ -139,7 +131,7 @@ public class RtmPresence {
     public func setUserState(
         inChannel channel: RtmChannelDetails,
         to state: [String: String],
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         let (channelName, channelType) = channel.objcVersion
         presence.setState(
@@ -150,13 +142,8 @@ public class RtmPresence {
                 stateItem.value = $0.value
                 return stateItem
             },
-            completion: { response, error in
-                guard let completion else { return }
-                if let response = response {
-                    completion(.success(.init(response)))
-                    return
-                }
-                completion(.failure(RtmBaseErrorInfo(from: error) ?? .noKnownError(operation: #function)))
+            completion: { resp, err in
+                RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
             })
     }
 
@@ -171,19 +158,14 @@ public class RtmPresence {
     public func removeUserState(
         fromChannel channel: RtmChannelDetails,
         keys: [String],
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         let (channelName, channelType) = channel.objcVersion
         presence.removeState(
             channelName, channelType: channelType,
             items: keys
-        ) { response, error in
-            guard let completion else { return }
-            if let response = response {
-                completion(.success(.init(response)))
-                return
-            }
-            completion(.failure(RtmBaseErrorInfo(from: error) ?? .noKnownError(operation: #function)))
+        ) { resp, error in
+            RtmClientKit.handleCompletion((resp, error), completion: completion, operation: #function)
         }
     }
 
@@ -192,21 +174,17 @@ public class RtmPresence {
     /// - Parameters:
     ///   - userId: The ID of the user.
     ///   - channel: The type and name of the channel.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmPresenceGetStateResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmPresenceGetStateResponse, RtmErrorInfo>`.
     public func getState(
         ofUser userId: String,
         fromChannel channel: RtmChannelDetails,
-        completion: @escaping (Result<RtmPresenceGetStateResponse, RtmBaseErrorInfo>) -> Void
+        completion: @escaping (Result<RtmPresenceGetStateResponse, RtmErrorInfo>) -> Void
     ) {
         let (channelName, channelType) = channel.objcVersion
         presence.getState(
             channelName, channelType: channelType,
-            userId: userId) { response, error in
-                if let response = response {
-                    completion(.success(.init(response)))
-                    return
-                }
-                completion(.failure(RtmBaseErrorInfo(from: error) ?? .noKnownError(operation: #function)))
+            userId: userId) { response, err in
+                RtmClientKit.handleCompletion((response, err), completion: completion, operation: #function)
             }
     }
 }

--- a/Sources/AgoraRtm/RtmStorage+Channel.swift
+++ b/Sources/AgoraRtm/RtmStorage+Channel.swift
@@ -16,16 +16,16 @@ extension RtmStorage {
     ///   - data: The metadata data to be set for the channel.
     ///   - options: The options for operating the metadata. Default is nil.
     ///   - lock: The lock for operating channel metadata. Default is nil.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmErrorInfo>`.
     public func setMetadata(
         forChannel channel: RtmChannelDetails,
         data: RtmMetadata,
         options: RtmMetadataOptions? = nil,
         lock: String? = nil,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         guard let metadata = data.agoraMetadata else {
-            completion?(.failure(RtmBaseErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")))
+            completion?(.failure(RtmErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")))
             return
         }
         let (channelName, channelType) = channel.objcVersion
@@ -34,12 +34,7 @@ extension RtmStorage {
             data: metadata,
             options: options?.objcVersion,
             lock: lock) { resp, err in
-                guard let completion else { return }
-                if let resp {
-                    completion(.success(.init(resp)))
-                    return
-                }
-                completion(.failure(.init(from: err) ?? .noKnownError(operation: #function)))
+                RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
             }
     }
 
@@ -51,7 +46,7 @@ extension RtmStorage {
     ///   - data: The metadata data to be set for the channel.
     ///   - options: The options for operating the metadata. Default is nil.
     ///   - lock: The lock for operating channel metadata. Default is nil.
-    /// - Throws: If the operation encounters an error, it throws an `RtmBaseErrorInfo`.
+    /// - Throws: If the operation encounters an error, it throws an `RtmErrorInfo`.
     /// - Returns: The operation result, an instance of `RtmCommonResponse`.
     @available(iOS 13.0.0, *)
     public func setMetadata(
@@ -61,19 +56,15 @@ extension RtmStorage {
         lock: String? = nil
     ) async throws -> RtmCommonResponse {
         guard let metadata = data.agoraMetadata else {
-            throw RtmBaseErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")
+            throw RtmErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")
         }
         let (channelName, channelType) = channel.objcVersion
-        let (resp, err) = await storage.setChannelMetadata(
+        return try RtmClientKit.handleCompletion(await storage.setChannelMetadata(
             channelName, channelType: channelType,
             data: metadata,
             options: options?.objcVersion,
             lock: lock
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Updates the metadata of a specified channel.
@@ -84,16 +75,16 @@ extension RtmStorage {
     ///   - data: The metadata data to be updated for the channel.
     ///   - options: The options for operating the metadata. Default is nil.
     ///   - lock: The lock for operating channel metadata. Default is nil.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmErrorInfo>`.
     public func updateMetadata(
         forChannel channel: RtmChannelDetails,
         data: RtmMetadata,
         options: RtmMetadataOptions? = nil,
         lock: String? = nil,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         guard let metadata = data.agoraMetadata else {
-            completion?(.failure(RtmBaseErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")))
+            completion?(.failure(RtmErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")))
             return
         }
         let (channelName, channelType) = channel.objcVersion
@@ -104,12 +95,7 @@ extension RtmStorage {
             options: agoraOptions,
             lock: lock,
             completion: { resp, err in
-                guard let completion else { return }
-                if let resp {
-                    completion(.success(.init(resp)))
-                    return
-                }
-                completion(.failure(.init(from: err) ?? .noKnownError(operation: #function)))
+                RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
             })
     }
 
@@ -121,7 +107,7 @@ extension RtmStorage {
     ///   - data: The metadata data to be set for the channel.
     ///   - options: The options for operating the metadata. Default is nil.
     ///   - lock: The lock for operating channel metadata. Default is nil.
-    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains ``RtmCommonResponse``. On failure, it contains ``RtmBaseErrorInfo``.
+    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains ``RtmCommonResponse``. On failure, it contains ``RtmErrorInfo``.
     @available(iOS 13.0.0, *)
     public func updateMetadata(
         forChannel channel: RtmChannelDetails,
@@ -130,19 +116,15 @@ extension RtmStorage {
         lock: String? = nil
     ) async throws -> RtmCommonResponse {
         guard let metadata = data.agoraMetadata else {
-            throw RtmBaseErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")
+            throw RtmErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")
         }
         let (channelName, channelType) = channel.objcVersion
-        let (resp, err) = await storage.updateChannelMetadata(
+        return try RtmClientKit.handleCompletion(await storage.updateChannelMetadata(
             channelName, channelType: channelType,
             data: metadata,
             options: options?.objcVersion,
             lock: lock
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Removes the metadata of a specified channel.
@@ -153,16 +135,16 @@ extension RtmStorage {
     ///   - data: The metadata data to be removed from the channel.
     ///   - options: The options for operating the metadata. Default is nil.
     ///   - lock: The lock for operating channel metadata. Default is nil.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmErrorInfo>`.
     public func removeMetadata(
         fromChannel channel: RtmChannelDetails,
         data: RtmMetadata,
         options: RtmMetadataOptions? = nil,
         lock: String? = nil,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         guard let metadata = data.agoraMetadata else {
-            completion?(.failure(RtmBaseErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")))
+            completion?(.failure(RtmErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")))
             return
         }
         let (channelName, channelType) = channel.objcVersion
@@ -173,11 +155,7 @@ extension RtmStorage {
             options: agoraOptions,
             lock: lock,
             completion: { resp, err in
-                guard let completion else { return }
-                if let resp {
-                    return completion(.success(.init(resp)))
-                }
-                completion(.failure(.init(from: err) ?? .noKnownError(operation: #function)))
+                RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
             })
     }
 
@@ -189,7 +167,7 @@ extension RtmStorage {
     ///   - data: The metadata data to be removed from the channel.
     ///   - options: The options for operating the metadata. Default is nil.
     ///   - lock: The lock for operating channel metadata. Default is nil.
-    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains ``RtmCommonResponse``. On failure, it contains ``RtmBaseErrorInfo``.
+    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains ``RtmCommonResponse``. On failure, it contains ``RtmErrorInfo``.
     @available(iOS 13.0.0, *)
     public func removeMetadata(
         fromChannel channel: RtmChannelDetails,
@@ -198,19 +176,15 @@ extension RtmStorage {
         lock: String? = nil
     ) async throws -> RtmCommonResponse {
         guard let metadata = data.agoraMetadata else {
-            throw RtmBaseErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")
+            throw RtmErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")
         }
         let (channelName, channelType) = channel.objcVersion
-        let (resp, err) = await storage.removeChannelMetadata(
+        return try RtmClientKit.handleCompletion(await storage.removeChannelMetadata(
             channelName, channelType: channelType,
             data: metadata,
             options: options?.objcVersion,
             lock: lock
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Retrieves the metadata of a specified channel.
@@ -218,19 +192,16 @@ extension RtmStorage {
     /// - Parameters:
     ///   - channelName: The name of the channel.
     ///   - channelType: The channel type, either RTM_CHANNEL_TYPE_STREAM or RTM_CHANNEL_TYPE_MESSAGE.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmGetMetadataResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmGetMetadataResponse, RtmErrorInfo>`.
     public func getMetadata(
         forChannel channel: RtmChannelDetails,
-        completion: @escaping (Result<RtmGetMetadataResponse, RtmBaseErrorInfo>) -> Void
+        completion: @escaping (Result<RtmGetMetadataResponse, RtmErrorInfo>) -> Void
     ) {
         let (channelName, channelType) = channel.objcVersion
         storage.getChannelMetadata(
             channelName, channelType: channelType
-        ) { metadata, err in
-            if let metadata {
-                return completion(.success(.init(metadata)))
-            }
-            completion(.failure(.init(from: err) ?? .noKnownError(operation: #function)))
+        ) { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         }
     }
 
@@ -238,19 +209,15 @@ extension RtmStorage {
     ///
     /// - Parameters:
     ///   - channel: The type and name of the channel.
-    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains an optional ``RtmGetMetadataResponse``. On failure, it contains `RtmBaseErrorInfo`.
+    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains an optional ``RtmGetMetadataResponse``. On failure, it contains `RtmErrorInfo`.
     @available(iOS 13.0.0, *)
     public func getMetadata(
         forChannel channel: RtmChannelDetails
     ) async throws -> RtmGetMetadataResponse {
         let (channelName, channelType) = channel.objcVersion
-        let (metadata, err) = await storage.channelMetadata(
+        return try RtmClientKit.handleCompletion(await storage.channelMetadata(
             channelName, channelType: channelType
-        )
-        guard let metadata else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(metadata)
+        ), operation: #function)
     }
 
 }

--- a/Sources/AgoraRtm/RtmStorage+User.swift
+++ b/Sources/AgoraRtm/RtmStorage+User.swift
@@ -14,15 +14,15 @@ extension RtmStorage {
     ///   - userId: The user ID of the specified user.
     ///   - data: The metadata data to be set for the user.
     ///   - options: The options for operating the metadata. Default is nil.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmErrorInfo>`.
     public func setUserMetadata(
         userId: String,
         data: RtmMetadata,
         options: RtmMetadataOptions? = nil,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         guard let metadata = data.agoraMetadata else {
-            completion?(.failure(RtmBaseErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")))
+            completion?(.failure(RtmErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")))
             return
         }
         let agoraOptions = options?.objcVersion
@@ -31,12 +31,7 @@ extension RtmStorage {
             data: metadata,
             options: agoraOptions,
             completion: { resp, err in
-                guard let completion else { return }
-                if let resp {
-                    completion(.success(.init(resp)))
-                    return
-                }
-                completion(.failure(.init(from: err) ?? .noKnownError(operation: #function)))
+                RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
             }
         )
     }
@@ -47,7 +42,7 @@ extension RtmStorage {
     ///   - userId: The user ID of the specified user.
     ///   - data: The metadata data to be set for the user.
     ///   - options: The options for operating the metadata. Default is nil.
-    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains ``RtmCommonResponse``. On failure, it contains ``RtmBaseErrorInfo``.
+    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains ``RtmCommonResponse``. On failure, it contains ``RtmErrorInfo``.
     @available(iOS 13.0.0, *)
     public func setUserMetadata(
         userId: String,
@@ -55,17 +50,13 @@ extension RtmStorage {
         options: RtmMetadataOptions? = nil
     ) async throws -> RtmCommonResponse {
         guard let metadata = data.agoraMetadata else {
-            throw RtmBaseErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")
+            throw RtmErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")
         }
-        let (resp, err) = await storage.setUserMetadata(
+        return try RtmClientKit.handleCompletion(await storage.setUserMetadata(
             userId,
             data: metadata,
             options: options?.objcVersion
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ),operation: #function)
     }
 
     /// Updates the metadata of a specified user.
@@ -74,15 +65,15 @@ extension RtmStorage {
     ///   - userId: The user ID of the specified user.
     ///   - data: The metadata data to be updated for the user.
     ///   - options: The options for operating the metadata. Default is nil.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmErrorInfo>`.
     public func updateUserMetadata(
         userId: String,
         data: RtmMetadata,
         options: RtmMetadataOptions? = nil,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         guard let metadata = data.agoraMetadata else {
-            completion?(.failure(RtmBaseErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")))
+            completion?(.failure(RtmErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")))
             return
         }
         let agoraOptions = options?.objcVersion
@@ -91,12 +82,7 @@ extension RtmStorage {
             data: metadata,
             options: agoraOptions,
             completion: { resp, err in
-                guard let completion else { return }
-                if let resp {
-                    completion(.success(.init(resp)))
-                    return
-                }
-                completion(.failure(.init(from: err) ?? .noKnownError(operation: #function)))
+                RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
             })
     }
 
@@ -106,7 +92,7 @@ extension RtmStorage {
     ///   - userId: The user ID of the specified user.
     ///   - data: The metadata data to be updated for the user.
     ///   - options: The options for operating the metadata. Default is nil.
-    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains `RtmCommonResponse`. On failure, it contains `RtmBaseErrorInfo`.
+    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains `RtmCommonResponse`. On failure, it contains `RtmErrorInfo`.
     @available(iOS 15.0.0, *)
     public func updateUserMetadata(
         userId: String,
@@ -114,17 +100,13 @@ extension RtmStorage {
         options: RtmMetadataOptions? = nil
     ) async throws -> RtmCommonResponse {
         guard let metadata = data.agoraMetadata else {
-            throw RtmBaseErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")
+            throw RtmErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")
         }
-        let (resp, err) = await storage.updateUserMetadata(
+        return try RtmClientKit.handleCompletion(await storage.updateUserMetadata(
             userId,
             data: metadata,
             options: options?.objcVersion
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ) ,operation: #function)
     }
 
     /// Removes the metadata of a specified user.
@@ -133,15 +115,15 @@ extension RtmStorage {
     ///   - userId: The user ID of the specified user.
     ///   - data: The metadata data to be removed from the user.
     ///   - options: The options for operating the metadata. Default is nil.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmErrorInfo>`.
     public func removeUserMetadata(
         userId: String,
         data: RtmMetadata,
         options: RtmMetadataOptions? = nil,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         guard let metadata = data.agoraMetadata else {
-            completion?(.failure(RtmBaseErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")))
+            completion?(.failure(RtmErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")))
             return
         }
         let agoraOptions = options?.objcVersion
@@ -150,12 +132,7 @@ extension RtmStorage {
             data: metadata,
             options: agoraOptions,
             completion: { resp, err in
-                guard let completion else { return }
-                if let resp {
-                    completion(.success(.init(resp)))
-                    return
-                }
-                completion(.failure(.init(from: err) ?? .noKnownError(operation: #function)))
+                RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
             })
     }
 
@@ -165,7 +142,7 @@ extension RtmStorage {
     ///   - userId: The user ID of the specified user.
     ///   - data: The metadata data to be removed from the user.
     ///   - options: The options for operating the metadata. Default is nil.
-    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains `RtmCommonResponse`. On failure, it contains `RtmBaseErrorInfo`.
+    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains `RtmCommonResponse`. On failure, it contains `RtmErrorInfo`.
     @available(iOS 13.0.0, *)
     public func removeUserMetadata(
         userId: String,
@@ -173,34 +150,26 @@ extension RtmStorage {
         options: RtmMetadataOptions? = nil
     ) async throws -> RtmCommonResponse {
         guard let metadata = data.agoraMetadata else {
-            throw RtmBaseErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")
+            throw RtmErrorInfo(errorCode: .storageInvalidMetadataItem, operation: #function, reason: "bad metadata")
         }
-        let (resp, err) = await storage.removeUserMetadata(
+        return try RtmClientKit.handleCompletion(await storage.removeUserMetadata(
             userId,
             data: metadata,
             options: options?.objcVersion
-        )
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Retrieves the metadata of a specified user.
     ///
     /// - Parameters:
     ///   - userId: The user ID of the specified user.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmGetMetadataResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmGetMetadataResponse, RtmErrorInfo>`.
     public func getUserMetadata(
         userId: String,
-        completion: @escaping (Result<RtmGetMetadataResponse, RtmBaseErrorInfo>) -> Void
+        completion: @escaping (Result<RtmGetMetadataResponse, RtmErrorInfo>) -> Void
     ) {
-        storage.getUserMetadata(userId) { metadata, err in
-            if let metadata {
-                completion(.success(.init(metadata)))
-                return
-            }
-            completion(.failure(.init(from: err) ?? .noKnownError(operation: #function)))
+        storage.getUserMetadata(userId) { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         }
     }
 
@@ -208,34 +177,27 @@ extension RtmStorage {
     ///
     /// - Parameters:
     ///   - userId: The user ID of the specified user.
-    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains an optional `RtmMetadata`. On failure, it contains `RtmBaseErrorInfo`.
+    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains an optional `RtmMetadata`. On failure, it contains `RtmErrorInfo`.
     @available(iOS 13.0.0, *)
     public func getUserMetadata(
         userId: String
     ) async throws -> RtmGetMetadataResponse? {
-        let (metadata, err) = await storage.userMetadata(userId)
-        guard let metadata else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return RtmGetMetadataResponse(metadata)
+        return try RtmClientKit.handleCompletion(
+            await storage.userMetadata(userId), operation: #function
+        )
     }
 
     /// Subscribes to the metadata update event of a specified user.
     ///
     /// - Parameters:
     ///   - userId: The user ID of the specified user.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmErrorInfo>`.
     public func subscribeUserMetadata(
         userId: String,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         storage.subscribeUserMetadata(userId) { resp, err in
-            guard let completion else { return }
-            if let resp {
-                completion(.success(.init(resp)))
-                return
-            }
-            completion(.failure(.init(from: err) ?? .noKnownError(operation: #function)))
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         }
     }
 
@@ -243,34 +205,25 @@ extension RtmStorage {
     ///
     /// - Parameters:
     ///   - userId: The user ID of the specified user.
-    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains `RtmCommonResponse`. On failure, it contains `RtmBaseErrorInfo`.
+    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains `RtmCommonResponse`. On failure, it contains `RtmErrorInfo`.
     @available(iOS 13.0.0, *)
     public func subscribeUserMetadata(
         userId: String
     ) async throws -> RtmCommonResponse {
-        let (resp, err) = await storage.subscribeUserMetadata(userId)
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(await storage.subscribeUserMetadata(userId), operation: #function)
     }
 
     /// Unsubscribes from the metadata update event of a specified user.
     ///
     /// - Parameters:
     ///   - userId: The user ID of the specified user.
-    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmBaseErrorInfo>`.
+    ///   - completion: The completion handler to be called with the operation result, `Result<RtmCommonResponse, RtmErrorInfo>`.
     public func unsubscribeUserMetadata(
         userId: String,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         storage.unsubscribeUserMetadata(userId) { resp, err in
-            guard let completion else { return }
-            if let resp {
-                completion(.success(.init(resp)))
-                return
-            }
-            completion(.failure(.init(from: err) ?? .noKnownError(operation: #function)))
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         }
     }
 
@@ -278,16 +231,12 @@ extension RtmStorage {
     ///
     /// - Parameters:
     ///   - userId: The user ID of the specified user.
-    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains `RtmCommonResponse`. On failure, it contains `RtmBaseErrorInfo`.
+    /// - Returns: A `Result` indicating the operation's success or failure. On success, it contains `RtmCommonResponse`. On failure, it contains `RtmErrorInfo`.
     @available(iOS 13.0.0, *)
     public func unsubscribeUserMetadata(
         userId: String
     ) async throws -> RtmCommonResponse {
-        let (resp, err) = await storage.unsubscribeUserMetadata(userId)
-        guard let resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(await storage.unsubscribeUserMetadata(userId), operation: #function)
     }
 
 }

--- a/Sources/AgoraRtm/RtmStreamChannel.swift
+++ b/Sources/AgoraRtm/RtmStreamChannel.swift
@@ -29,19 +29,13 @@ open class RtmStreamChannel: NSObject {
     /// - Parameters:
     ///   - option: The ``RtmJoinChannelOption`` to use for joining the channel.
     ///   - completion: An optional completion block that will be called with the result of the operation.
-    ///                 The result will contain either a successful ``RtmCommonResponse`` or an error of type `RtmBaseErrorInfo`.
+    ///                 The result will contain either a successful ``RtmCommonResponse`` or an error of type `RtmErrorInfo`.
     public func join(
         with option: RtmJoinChannelOption,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
-        channel.join(with: option.objcVersion) { resp, errInfo in
-            guard let completion = completion else { return }
-            guard let resp = resp else {
-                return completion(.failure(RtmBaseErrorInfo(from: errInfo) ??
-                    .noKnownError(operation: #function)))
-//                return completion(.failure(JoinErrorInfo(from: errInfo) ?? .noKnownError))
-            }
-            completion(.success(.init(resp)))
+        channel.join(with: option.objcVersion) { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         }
     }
 
@@ -51,45 +45,34 @@ open class RtmStreamChannel: NSObject {
     ///
     /// - Parameter option: The configuration options for joining the channel, encapsulated in an ``RtmJoinChannelOption`` object.
     ///
-    /// - Throws: ``RtmBaseErrorInfo`` if an error occurs during the join attempt.
+    /// - Throws: ``RtmErrorInfo`` if an error occurs during the join attempt.
     ///
     /// - Returns: A response confirming the result of the join attempt, encapsulated in an ``RtmCommonResponse`` object.
     @available(iOS 13.0.0, *)
     public func join(
         with option: RtmJoinChannelOption
     ) async throws -> RtmCommonResponse {
-        let (resp, err) = await channel.join(with: option.objcVersion)
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(
+            await channel.join(with: option.objcVersion), operation: #function
+        )
     }
 
 
     /// Leaves the stream channel.
     ///
     /// - Parameter completion: An optional completion block that will be called with the result of the operation.
-    ///                         The result will contain either a successful ``RtmCommonResponse`` or an error of type ``RtmBaseErrorInfo``.
+    ///                         The result will contain either a successful ``RtmCommonResponse`` or an error of type ``RtmErrorInfo``.
     public func leave(
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
-        channel.leave { resp, errInfo in
-            guard let completion = completion else { return }
-            guard let resp = resp else {
-                return completion(.failure(RtmBaseErrorInfo(from: errInfo) ??
-                    .noKnownError(operation: #function)))
-            }
-            completion(.success(.init(resp)))
+        channel.leave { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         }
     }
 
     @available(iOS 13.0.0, *)
     public func leave() async throws -> RtmCommonResponse {
-        let (resp, err) = await channel.leave()
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(await channel.leave(), operation: #function)
     }
 
 
@@ -98,28 +81,19 @@ open class RtmStreamChannel: NSObject {
     /// - Parameters:
     ///   - token: The new token to renew.
     ///   - completion: An optional completion block that will be called with the result of the operation.
-    ///                 The result will contain either a successful ``RtmCommonResponse`` or an error of type `RtmBaseErrorInfo`.
+    ///                 The result will contain either a successful ``RtmCommonResponse`` or an error of type `RtmErrorInfo`.
     public func renewToken(
         _ token: String,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
-        channel.renewToken(token, completion: { resp, errInfo in
-            guard let completion = completion else { return }
-            guard let resp = resp else {
-                return completion(.failure(RtmBaseErrorInfo(from: errInfo) ??
-                    .noKnownError(operation: #function)))
-            }
-            completion(.success(.init(resp)))
+        channel.renewToken(token, completion: { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         })
     }
 
     @available(iOS 13.0.0, *)
     public func renewToken(_ token: String) async throws -> RtmCommonResponse {
-        let (resp, err) = await channel.renewToken(token)
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(await channel.renewToken(token), operation: #function)
     }
 
     /// Joins the stream channel with the provided ``RtmJoinChannelOption``.
@@ -128,18 +102,13 @@ open class RtmStreamChannel: NSObject {
     ///   - topic: The name of the stream channel to join.
     ///   - option: The ``RtmJoinTopicOption`` to use for joining the channel.
     ///   - completion: An optional completion block that will be called with the result of the operation.
-    ///                 The result will contain either a successful `RtmCommonResponse` or an error of type `RtmBaseErrorInfo`.
+    ///                 The result will contain either a successful `RtmCommonResponse` or an error of type `RtmErrorInfo`.
     public func joinTopic(
         _ topic: String, with option: RtmJoinTopicOption?,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
-        channel.joinTopic(topic, with: option?.objcVersion, completion:  { resp, errInfo in
-            guard let completion = completion else { return }
-            guard let resp = resp else {
-                return completion(.failure(RtmBaseErrorInfo(from: errInfo) ??
-                    .noKnownError(operation: #function)))
-            }
-            completion(.success(.init(resp)))
+        channel.joinTopic(topic, with: option?.objcVersion, completion:  { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         })
     }
 
@@ -149,16 +118,15 @@ open class RtmStreamChannel: NSObject {
     ///   - topic: The name of the stream channel to join.
     ///   - option: The ``RtmJoinTopicOption`` to use for joining the channel.
     /// - Returns: A ``RtmCommonResponse`` object representing the result of the operation.
-    /// - Throws: An error of type ``RtmBaseErrorInfo`` if the operation fails.
+    /// - Throws: An error of type ``RtmErrorInfo`` if the operation fails.
     @discardableResult @available(iOS 13.0.0, *)
     public func joinTopic(
         _ topic: String, with option: RtmJoinTopicOption?
     ) async throws -> RtmCommonResponse {
-        let (resp, err) = await channel.joinTopic(topic, with: option?.objcVersion)
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(
+            await channel.joinTopic(topic, with: option?.objcVersion),
+            operation: #function
+        )
     }
 
     /// Leaves the stream channel.
@@ -167,18 +135,13 @@ open class RtmStreamChannel: NSObject {
     ///   - topic: The name of the stream channel to leave.
     ///   - completion: An optional completion block that will be called with the result of the operation.
     ///                 The result will contain either a successful ``RtmCommonResponse``
-    ///                 or an error of type ``RtmBaseErrorInfo``.
+    ///                 or an error of type ``RtmErrorInfo``.
     public func leaveTopic(
         _ topic: String,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
-        channel.leaveTopic(topic, completion: { resp, errInfo in
-            guard let completion = completion else { return }
-            guard let resp = resp else {
-                return completion(.failure(RtmBaseErrorInfo(from: errInfo) ??
-                    .noKnownError(operation: #function)))
-            }
-            completion(.success(.init(resp)))
+        channel.leaveTopic(topic, completion: { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         })
     }
 
@@ -186,16 +149,12 @@ open class RtmStreamChannel: NSObject {
     ///
     /// - Parameter topic: The name of the stream channel to leave.
     /// - Returns: A ``RtmCommonResponse`` object representing the result of the operation.
-    /// - Throws: An error of type ``RtmBaseErrorInfo`` if the operation fails.
+    /// - Throws: An error of type ``RtmErrorInfo`` if the operation fails.
     @discardableResult @available(iOS 13.0.0, *)
     public func leaveTopic(
         _ topic: String
     ) async throws -> RtmCommonResponse {
-        let (resp, err) = await channel.leaveTopic(topic)
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(await channel.leaveTopic(topic), operation: #function)
     }
 
     /// Subscribes to messages from specified users within a topic.
@@ -207,17 +166,13 @@ open class RtmStreamChannel: NSObject {
     ///   - options: Subscription options using ``RtmTopicOption``, including users to subscribe to.
     ///              Use `nil` to subscribe to all.
     ///   - completion: An optional completion handler that returns either a successful response
-    ///                 (``RtmTopicSubscriptionResponse``) or an error (``RtmBaseErrorInfo``). Defaults to nil.
+    ///                 (``RtmTopicSubscriptionResponse``) or an error (``RtmErrorInfo``). Defaults to nil.
     public func subscribe(
         toTopic topic: String, withOptions options: RtmTopicOption? = nil,
-        completion: ((Result<RtmTopicSubscriptionResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmTopicSubscriptionResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
-        channel.subscribeTopic(topic, with: options?.objcVersion, completion: { resp, errInfo in
-            guard let completion = completion else { return }
-            guard let resp = resp else {
-                return completion(.failure(RtmBaseErrorInfo(from: errInfo) ?? .noKnownError(operation: #function)))
-            }
-            completion(.success(.init(resp)))
+        channel.subscribeTopic(topic, with: options?.objcVersion, completion: { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         })
     }
 
@@ -230,16 +185,15 @@ open class RtmStreamChannel: NSObject {
     ///
     /// - Returns:
     ///   A result that either provides a successful response ``RtmTopicSubscriptionResponse``
-    ///   or throws an error ``RtmBaseErrorInfo``.
+    ///   or throws an error ``RtmErrorInfo``.
     @discardableResult @available(iOS 13.0.0, *)
     public func subscribe(
         toTopic topic: String, withOptions options: RtmTopicOption? = nil
     ) async throws -> RtmTopicSubscriptionResponse {
-        let (resp, err) = await channel.subscribeTopic(topic, with: options?.objcVersion)
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(
+            await channel.subscribeTopic(topic, with: options?.objcVersion),
+            operation: #function
+        )
     }
 
     /// Unsubscribes from specified users' messages within a topic.
@@ -251,17 +205,13 @@ open class RtmStreamChannel: NSObject {
     ///   - options: Subscription options using ``RtmTopicOption``, including users to unsubscribe to.
     ///              Use `nil` to unsubscribe to all.
     ///   - completion: An optional completion handler that returns either a successful response ``RtmCommonResponse``
-    ///                 or an error ``RtmBaseErrorInfo``.
+    ///                 or an error ``RtmErrorInfo``.
     public func unsubscribe(
         fromTopic topic: String, withOptions options: RtmTopicOption? = nil,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
-        channel.unsubscribeTopic(topic, with: options?.objcVersion, completion: { resp, errInfo in
-            guard let completion = completion else { return }
-            guard let resp = resp else {
-                return completion(.failure(RtmBaseErrorInfo(from: errInfo) ?? .noKnownError(operation: #function)))
-            }
-            completion(.success(.init(resp)))
+        channel.unsubscribeTopic(topic, with: options?.objcVersion, completion: { resp, err in
+            RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
         })
     }
 
@@ -274,16 +224,15 @@ open class RtmStreamChannel: NSObject {
     ///
     /// - Returns:
     ///   A result that either provides a successful response ``RtmCommonResponse``
-    ///   or throws an error ``RtmBaseErrorInfo``.
+    ///   or throws an error ``RtmErrorInfo``.
     @discardableResult @available(iOS 13.0.0, *)
     public func unsubscribe(
         fromTopic topic: String, withOptions options: RtmTopicOption? = nil
     ) async throws -> RtmCommonResponse {
-        let (resp, err) = await channel.unsubscribeTopic(topic, with: options?.objcVersion)
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        return try RtmClientKit.handleCompletion(
+            await channel.unsubscribeTopic(topic, with: options?.objcVersion),
+            operation: #function
+        )
     }
 
     /// Publishes a message to a specified topic asynchronously.
@@ -292,19 +241,19 @@ open class RtmStreamChannel: NSObject {
     ///   - message: The message to be published. Must be `Codable`.
     ///   - topic: The name of the topic to which the message will be published.
     ///   - options: Optional configurations for publishing the message. Defaults to `nil`.
-    ///   - completion: A completion block that returns a result containing an ``RtmCommonResponse`` or ``RtmBaseErrorInfo``.
+    ///   - completion: A completion block that returns a result containing an ``RtmCommonResponse`` or ``RtmErrorInfo``.
     public func publishTopicMessage(
         _ message: Codable, in topic: String, with options: RtmPublishOptions?,
-        completion: ((Result<RtmCommonResponse, RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<RtmCommonResponse, RtmErrorInfo>) -> Void)? = nil
     ) {
         let msgString: String
         do {
             msgString = try message.convertToString()
-        } catch let error as RtmBaseErrorInfo {
+        } catch let error as RtmErrorInfo {
             completion?(.failure(error))
             return
         } catch {
-            completion?(.failure(RtmBaseErrorInfo(
+            completion?(.failure(RtmErrorInfo(
                 errorCode: .channelInvalidMessage, operation: #function,
                 reason: "could not encode message: \(error.localizedDescription)"
             )))
@@ -313,13 +262,8 @@ open class RtmStreamChannel: NSObject {
         channel.publishTopicMessage(
             msgString as NSString, inTopic: topic,
             withOption: options?.objcVersion,
-            completion: { resp, errInfo in
-                guard let completion = completion else { return }
-                guard let resp = resp else {
-                    return completion(.failure(RtmBaseErrorInfo(from: errInfo) ??
-                        .noKnownError(operation: #function)))
-                }
-                completion(.success(.init(resp)))
+            completion: { resp, err in
+                RtmClientKit.handleCompletion((resp, err), completion: completion, operation: #function)
             }
         )
     }
@@ -335,7 +279,7 @@ open class RtmStreamChannel: NSObject {
     ///
     /// - Returns: An ``RtmCommonResponse`` containing information about the published message.
     ///
-    /// - Throws: ``RtmBaseErrorInfo`` if an error occurs during the publishing process.
+    /// - Throws: ``RtmErrorInfo`` if an error occurs during the publishing process.
     @discardableResult @available(iOS 13.0.0, *)
     public func publishTopicMessage(
         message: Codable,
@@ -344,21 +288,17 @@ open class RtmStreamChannel: NSObject {
         let msgString: String
         do {
             msgString = try message.convertToString()
-        } catch let error as RtmBaseErrorInfo {
+        } catch let error as RtmErrorInfo {
             throw error
         } catch {
-            throw RtmBaseErrorInfo(
+            throw RtmErrorInfo(
                 errorCode: .channelInvalidMessage, operation: #function,
                 reason: "could not encode message: \(error.localizedDescription)"
             )
         }
-        let (resp, err) = await channel.publishTopicMessage(
+        return try RtmClientKit.handleCompletion(await channel.publishTopicMessage(
             msgString as NSString, inTopic: topic, withOption: options?.objcVersion
-        )
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
-        return .init(resp)
+        ), operation: #function)
     }
 
     /// Retrieves the list of subscribed users from a stream channel.
@@ -366,16 +306,16 @@ open class RtmStreamChannel: NSObject {
     /// - Parameters:
     ///   - topic: The name of the stream channel to retrieve the list of subscribed users from.
     ///   - completion: An optional completion block that will be called with the result of the operation.
-    ///                 The result will contain either a successful array of user IDs or an error of type ``RtmBaseErrorInfo``.
+    ///                 The result will contain either a successful array of user IDs or an error of type ``RtmErrorInfo``.
     public func getSubscribedUserList(
         forTopic topic: String,
-        completion: ((Result<[String], RtmBaseErrorInfo>) -> Void)? = nil
+        completion: ((Result<[String], RtmErrorInfo>) -> Void)? = nil
     ) {
-        channel.getSubscribedUserList(topic, completion: { resp, errInfo in
+        channel.getSubscribedUserList(topic, completion: { resp, err in
             guard let completion = completion else { return }
+            if let err = RtmErrorInfo(from: err) { return completion(.failure(err)) }
             guard let resp = resp else {
-                return completion(.failure(RtmBaseErrorInfo(from: errInfo) ??
-                    .noKnownError(operation: #function)))
+                return completion(.failure(RtmErrorInfo.noKnownError(operation: #function)))
             }
             completion(.success(resp.users))
         })
@@ -385,22 +325,21 @@ open class RtmStreamChannel: NSObject {
     ///
     /// - Parameter topic: The name of the stream channel to retrieve the list of subscribed users from.
     /// - Returns: An array of user IDs representing the list of subscribed users.
-    /// - Throws: An error of type ``RtmBaseErrorInfo`` if the operation fails.
+    /// - Throws: An error of type ``RtmErrorInfo`` if the operation fails.
     @available(iOS 13.0.0, *)
     public func getSubscribedUserList(
         forTopic topic: String
     ) async throws -> [String] {
         let (resp, err) = await channel.subscribedUserList(topic)
-        guard let resp = resp else {
-            throw RtmBaseErrorInfo(from: err) ?? .noKnownError(operation: #function)
-        }
+        if let err = RtmErrorInfo(from: err) { throw err }
+        guard let resp = resp else { throw RtmErrorInfo.noKnownError(operation: #function) }
         return resp.users
     }
 
     /// Destroys the stream channel.
     ///
     /// - Returns: The error code associated with the destruction of the channel, or `nil` if the destruction is successful.
-    func destroy() -> RtmBaseErrorCode? {
+    func destroy() -> RtmErrorCode? {
         let destroyCode = channel.destroy()
         if destroyCode == .ok { return nil }
         return .init(rawValue: destroyCode.rawValue)

--- a/Sources/AgoraRtm/Utilities+Encodable.swift
+++ b/Sources/AgoraRtm/Utilities+Encodable.swift
@@ -27,7 +27,7 @@ internal extension Encodable {
         let msg = try JSONEncoder().encode(self)
 
         guard let jsonString = String(data: msg, encoding: .utf8) else {
-            throw RtmBaseErrorInfo(
+            throw RtmErrorInfo(
                 errorCode: .channelInvalidMessage, operation: #function,
                 reason: "message could not convert to JSON String"
             )


### PR DESCRIPTION
- All OC responses go through `RtmClientKit/handleCompletion(:,completion:operation:)` or `RtmClientKit/handleCompletion(:,operation:)` so they can be updated easier in the future
  - Inline docs updated to reflect this

## Renaming
- `RtmBaseErrorInfo` -> `RtmErrorInfo`
- `RtmBaseErrorCode` -> `RtmErrorCode`